### PR TITLE
Support for creating GitHub issue comments based on pinned Slack messages

### DIFF
--- a/backend/bot/api/routes/user.py
+++ b/backend/bot/api/routes/user.py
@@ -183,6 +183,13 @@ def return_user_list():
 @jwt_required()
 def patch_delete_user(user_id):
     user = db_user_lookup(id=user_id)
+    if not user:
+        logger.error("User not found id: %s (%s %s)", user_id, request.method, request.json)
+        return (
+            jsonify({"error": "User not found"}),
+            500,
+            {"ContentType": "application/json"},
+        )
     match request.method:
         case "DELETE":
             success, error = db_user_delete(email=user.email)

--- a/backend/bot/github/__init__.py
+++ b/backend/bot/github/__init__.py
@@ -1,0 +1,2 @@
+from .api import GithubApi
+from .issue import GithubIssue

--- a/backend/bot/github/api.py
+++ b/backend/bot/github/api.py
@@ -1,8 +1,8 @@
 import config
 
-from typing import List, Type, TypeVar
+from typing import Generator, Optional, Type, TypeVar
 from dataclasses import dataclass, field
-from github import Github, Repository
+from github import Github, Issue, Repository
 
 logger = config.log.get_logger("github.api")
 
@@ -60,3 +60,14 @@ class GithubApi:
 
     def test(self) -> bool:
         return self.repo is not None
+
+    def list_issues(self) -> Generator[Issue, None, None]:
+        for issue in self.repo.get_issues():
+            yield issue
+
+    def get_issue_by_link(self, link: str) -> Optional[Issue]:
+        for issue in self.list_issues():
+            if issue.html_url == link:
+                return issue
+        logger.debug("%s:get_issue_by_link: issue with link '%s' not found", self.__class__.__name__, link)
+        return None

--- a/backend/bot/shared/tools.py
+++ b/backend/bot/shared/tools.py
@@ -15,21 +15,30 @@ random_suffix = "".join(
 timestamp_fmt = "%Y-%m-%dT%H:%M:%S %Z"
 timestamp_fmt_short = "%d/%m/%Y %H:%M:%S %Z"
 
-application_timezone = config.active.options.get("timezone")
+application_timezone = timezone(config.active.options.get("timezone"))
+
+
+def db_timestamp(ts: datetime) -> str:
+    if ts.tzinfo:
+        if ts.tzinfo != application_timezone:
+            return ts.astimezone(application_timezone).strftime(timestamp_fmt_short)
+        else:
+            return ts.strftime(timestamp_fmt_short)
+    else:
+        return application_timezone.localize(ts).strftime(timestamp_fmt_short)
 
 
 def fetch_timestamp(short: bool = False):
     """Return a localized, formatted timestamp using datetime.now()"""
-    now = datetime.now()
-    localized = timezone(application_timezone).localize(now)
+    now = datetime.now(tz=application_timezone)
     if short:
-        return localized.strftime(timestamp_fmt_short)
-    return localized.strftime(timestamp_fmt)
+        return now.strftime(timestamp_fmt_short)
+    return now.strftime(timestamp_fmt)
 
 
 def fetch_timestamp_from_time_obj(t: datetime):
     """Return a localized, formatted timestamp using datetime.datetime class"""
-    return timezone(application_timezone).localize(t).strftime(timestamp_fmt)
+    return application_timezone.localize(t).strftime(timestamp_fmt)
 
 
 def find_index_in_list(lst: List, key: Any, value: Any):

--- a/backend/bot/slack/handler.py
+++ b/backend/bot/slack/handler.py
@@ -1,4 +1,6 @@
 import asyncio
+import re
+
 import config
 import requests
 import slack_sdk
@@ -238,7 +240,7 @@ def make_reacji_incident(reaction, channel_id, timestamp):
 @dataclass
 class FileInfo:
     """
-    Information about a file data attached to a Slack message
+    Information about a file attached to a Slack message
     """
     name: str
     mimetype: str
@@ -249,7 +251,7 @@ class FileInfo:
 
 class MessageContent:
     """
-    Representation of a Slack message content for the purpose of storing pinned content
+    Representation of a Slack message for the purpose of storing pinned content
     """
     def __init__(self, message):
         self.user = get_user_name(user_id=message["user"])
@@ -371,9 +373,26 @@ def reaction_added(event, say):
         )
 
 
-"""
-Helper Functions
-"""
+@app.event("pin_added")
+def pin_added(event, say):
+    logger.debug("pin_added: event: %s", event)
+    channel_id = event["item"]["channel"]
+    try:
+        incident = db_read_incident(channel_id=channel_id)
+        logger.debug("pin_added: incident '%s", incident)
+    except Exception as exc:
+        logger.debug("pin_added: Failed to lookup incident with channel_id: '%s' - error: %s",
+                     channel_id, exc)
+        # Not a channel matching any incident tracked in the DB =>  nothing to do
+        return
+    if event["item"]["type"] != "message":
+        logger.debug("pin_added: not a message, ignoring")
+        # not a pinned message => nothing to do
+        return
+    message = MessageContent(event["item"]["message"])
+    message.store_to_db(incident.incident_id, lambda x: say(channel=channel_id, text=f":wave: {x}"))
+    if config.active.integrations.get("github"):
+        message.as_github_issue_comment(incident)
 
 
 @app.event("message")
@@ -464,89 +483,35 @@ def handle_message_events(body):
 
 
 """
-Statuspage
+Statuspage actions
 """
 
 
-@app.action("statuspage.components_select")
-def handle_static_action(ack, body):
-    logger.debug(body)
-    ack()
-
-
-@app.action("statuspage.components_status_select")
-def handle_static_action(ack, body):
-    logger.debug(body)
-    ack()
-
-
-@app.action("statuspage.impact_select")
-def handle_static_action(ack, body):
-    logger.debug(body)
-    ack()
-
-
-@app.action("statuspage.open_statuspage")
-def handle_static_action(ack, body):
-    logger.debug(body)
-    ack()
-
-
-@app.action("statuspage.update_status")
-def handle_static_action(ack, body):
-    logger.debug(body)
-    ack()
-
-
-@app.action("statuspage.view_incident")
-def handle_static_action(ack, body):
-    logger.debug(body)
+@app.action(re.compile(r"^statuspage.*"))
+def statuspage_action(ack, body):
+    logger.debug("statuspage_action: body: %s", body)
     ack()
 
 
 """
-Jira
+Jira actions
 """
 
 
-@app.action("jira.description_input")
-def handle_static_action(ack, body):
-    logger.debug(body)
-    ack()
-
-
-@app.action("jira.priority_select")
-def handle_static_action(ack, body):
-    logger.debug(body)
-    ack()
-
-
-@app.action("jira.summary_input")
-def handle_static_action(ack, body):
-    logger.debug(body)
-    ack()
-
-
-@app.action("jira.type_select")
-def handle_static_action(ack, body):
-    logger.debug(body)
-    ack()
-
-
-@app.action("jira.view_issue")
-def handle_static_action(ack, body):
-    logger.debug(body)
+@app.action(re.compile(r"^jira.*"))
+def jira_action(ack, body):
+    logger.debug("jira_action: body: %s", body)
     ack()
 
 
 """
-Logs for request handling various other requests
+Other actions
 """
 
 
 @app.action("dismiss_message")
-def handle_dismiss_message(ack, body):
-    logger.debug(body)
+def dismiss_message_action(ack, body):
+    logger.debug("dismiss_message_action: body: %s", body)
     try:
         ack()
         slack_web_client.chat_delete(
@@ -556,73 +521,31 @@ def handle_dismiss_message(ack, body):
         logger.error(f"Error deleting message: {error}")
 
 
-@app.action("incident.incident_postmortem_link")
-def handle_static_action(ack, body, logger):
-    logger.debug(body)
+@app.action(re.compile(r"^incident.*"))
+def incident_action(ack, body):
+    logger.debug("incident_action: body: %s", body)
     ack()
 
 
-@app.action("incident.click_conference_bridge_link")
-def handle_static_action(ack, body, logger):
-    logger.debug(body)
+@app.action(re.compile(r"^external.*"))
+def external_action(ack, body):
+    logger.debug("external_action: body: %s", body)
     ack()
 
 
-@app.action("incident.incident_guide_link")
-def handle_static_action(ack, body, logger):
-    logger.debug(body)
-    ack()
-
-
-@app.action("incident.join_incident_channel")
-def handle_static_action(ack, body, logger):
-    logger.debug(body)
-    ack()
-
-
-@app.action("external.reload")
-def handle_static_action(ack, body, logger):
-    logger.debug(body)
-    ack()
-
-
-@app.action("external.view_status_page")
-def handle_static_action(ack, body, logger):
-    logger.debug(body)
-    ack()
-
-
-@app.action("incident_update_modal_select_incident")
-def handle_static_action(ack, body, logger):
-    logger.debug(body)
+@app.action(re.compile(r"^incident_update_modal_.*"))
+def incident_update_modal_action(ack, body):
+    logger.debug("incident_update_modal_action: body: %s", body)
     ack()
 
 
 @app.action("open_rca")
-def handle_static_action(ack, body, logger):
-    logger.debug(body)
+def open_rca_action(ack, body):
+    logger.debug("open_rca_action: body: %s", body)
     ack()
 
 
-@app.action("open_incident_modal_set_severity")
-def handle_static_action(ack, body, logger):
-    logger.debug(body)
-    ack()
-
-
-@app.action("open_incident_modal_set_security_type")
-def handle_static_action(ack, body, logger):
-    logger.debug(body)
-    ack()
-
-
-@app.action("open_incident_modal_set_private")
-def handle_static_action(ack, body, logger):
-    logger.debug(body)
-    ack()
-
-
-@app.action("view_statuspage_incident")
-def handle_static_action(ack, body, logger):
-    logger.debug(body)
+@app.action(re.compile(r"^open_incident_modal_.*"))
+def open_incident_modal_action(ack, body):
+    logger.debug("open_incident_modal_action: body: %s", body)
     ack()

--- a/backend/bot/slack/handler.py
+++ b/backend/bot/slack/handler.py
@@ -3,6 +3,9 @@ import config
 import requests
 import slack_sdk
 import variables
+from typing import Any, Dict, List
+from dataclasses import dataclass
+from datetime import datetime, timezone
 
 from bot.exc import ConfigurationError
 from bot.incident import actions as inc_actions, incident
@@ -23,9 +26,10 @@ from bot.slack.messages import (
     job_list_message,
     pd_on_call_message,
 )
+from bot.github import GithubIssue
+from bot.models.incident import db_read_incident
 from slack_bolt import App
 from slack_sdk.errors import SlackApiError
-from typing import Any, Dict
 
 logger = config.log.get_logger("slack.handler")
 
@@ -40,7 +44,7 @@ def custom_error_handler(error, body, logger):
 
 
 # The import statement bellow is seemingly unused, it is though needed to register Bolt UI components and callbacks
-# The registrations is a side-effect of the import
+# The registrations is a side effect of the import
 from . import modals
 
 tracking = DigestMessageTracking()
@@ -190,130 +194,181 @@ Reactions
 """
 
 
+def make_reacji_incident(reaction, channel_id, timestamp):
+    """"
+    Incident creation based on the reacji channeler
+    """
+    if (config.active.options.get("create_from_reaction", {"enabled": False})["enabled"] or
+            reaction != config.active.options.get("create_from_reaction").get("reacji")):
+        # not a reacji message or incident creation based on reaction is not enabled
+        return False
+
+    # Retrieve the content of the message that was reacted to
+    try:
+        result = slack_web_client.conversations_history(channel=channel_id,
+                                                        inclusive=True,
+                                                        oldest=timestamp,
+                                                        limit=1)
+    except Exception as error:
+        logger.error(f"Failed to retrieve a message: error: %s", error)
+        return True
+    # Create request parameters object
+    try:
+        request_parameters = incident.RequestParameters(
+            channel=channel_id,
+            incident_description=f"auto-{tools.random_suffix}",
+            user="internal_auto_create",
+            severity="sev4",
+            message_reacted_to_content=result["messages"][0]["text"],
+            original_message_timestamp=timestamp,
+            is_security_incident=False,
+            private_channel=False,
+        )
+    except ConfigurationError as error:
+        logger.error("Failed to create incident request: error: %s", error)
+        return True
+    # Create an incident based on the message using the internal path
+    try:
+        incident.create_incident(internal=True, request_parameters=request_parameters)
+    except Exception as error:
+        logger.error(f"Failed to create new incident: error: %s", error)
+    return True
+
+
+@dataclass
+class FileInfo:
+    """
+    Information about a file data attached to a Slack message
+    """
+    name: str
+    mimetype: str
+    content: Any
+    timestamp: datetime
+    link: str
+
+
+class MessageContent:
+    """
+    Representation of a Slack message content for the purpose of storing pinned content
+    """
+    def __init__(self, message):
+        self.user = get_user_name(user_id=message["user"])
+        self.timestamp = datetime.fromtimestamp(float(message["ts"]), tz=timezone.utc)
+        self.text = message["text"]
+        self.files: List[FileInfo] = []
+        for file in message.get("files", []):
+            try:
+                res = requests.get(
+                    file["url_private"],
+                    headers={"Authorization": f"Bearer {config.slack_bot_token}"},
+                    params={"pub_secret": file["permalink_public"].split("-")[3]},
+                )
+            except Exception as exc:
+                logger.error("Failed to download file '%s', error: %s", file["name"], exc)
+                continue
+            self.files.append(
+                FileInfo(
+                    name=file["name"],
+                    mimetype=file["mimetype"],
+                    timestamp=datetime.fromtimestamp(float(file["timestamp"]), tz=timezone.utc),
+                    content=res.content,
+                    link=file["url_private"]
+                )
+            )
+
+    def __str__(self):
+        return ",".join([f"{k}:{v}" for k,v in self.__dict__.items()])
+
+    def store_to_db(self, incident_id, error_reporter):
+        non_images = [f for f in self.files if "image" not in f.mimetype]
+        if non_images:
+            error_reporter(f"{len(non_images)} non-image file(s) ignored. I can currently only attach images.")
+
+        nr_images = 0
+        for file in [f for f in self.files if "image" in f.mimetype]:
+            write_content(
+                incident_id=incident_id,
+                title=file.name,
+                img=file.content,
+                mimetype=file.mimetype,
+                ts=tools.db_timestamp(file.timestamp),
+                user=self.user,
+            )
+            nr_images += 1
+        write_content(
+            incident_id=incident_id,
+            content=self.text,
+            ts=tools.db_timestamp(self.timestamp),
+            user=self.user,
+        )
+        logger.debug("reaction_added: incident_id: '%s' pinned content stored to DB, text: '%s' %d images",
+                     incident_id, self.text, nr_images)
+
+    def as_github_issue_comment(self, incident):
+        try:
+            issue = GithubIssue(incident)
+            issue.create_comment(self.text + "\n" + "\n".join([f"[{f.name}]({f.link})" for f in self.files]))
+        except RuntimeError as exc:
+            logger.error("Failed to store pinned content in GitHub issue - error: '%s'", exc)
+
+
 @app.event("reaction_added")
 def reaction_added(event, say):
+    logger.debug("reaction_added: event: %s, say: %s", event, say)
     emoji = event["reaction"]
     channel_id = event["item"]["channel"]
     ts = event["item"]["ts"]
     # Automatically create incident based on reaction with specific emoji
-    if emoji == config.active.options.get("create_from_reaction").get(
-        "reacji"
-    ) and config.active.options.get("create_from_reaction").get("enabled"):
-        # Retrieve the content of the message that was reacted to
-        try:
-            result = slack_web_client.conversations_history(
-                channel=channel_id, inclusive=True, oldest=ts, limit=1
-            )
-            message = result["messages"][0]
-            message_reacted_to_content = message["text"]
-        except Exception as error:
-            logger.error(f"Error when trying to retrieve a message: {error}")
-        # Create request parameters object
-        try:
-            request_parameters = incident.RequestParameters(
-                channel=channel_id,
-                incident_description=f"auto-{tools.random_suffix}",
-                user="internal_auto_create",
-                severity="sev4",
-                message_reacted_to_content=message_reacted_to_content,
-                original_message_timestamp=ts,
-                is_security_incident=False,
-                private_channel=False,
-            )
-        except ConfigurationError as error:
-            logger.error(error)
-        # Create an incident based on the message using the internal path
-        try:
-            incident.create_incident(
-                internal=True, request_parameters=request_parameters
-            )
-        except Exception as error:
-            logger.error(f"Error when trying to create an incident: {error}")
+    logger.debug("reaction: channel_id: %s ts: %s emoji: %s", channel_id, emoji, ts)
+
+    if make_reacji_incident(emoji, channel_id, ts):
+        # reaction was from reacji, we are done
+        return
+
+    if emoji != "pushpin":
+        # Not a pinned content
+        return
+
     # Pinned content for incidents
-    if emoji == "pushpin":
-        channel_info = slack_web_client.conversations_info(channel=channel_id)
-        if "inc-" in channel_info["channel"]["name"]:
-            # Retrieve the content of the message that was reacted to
-            try:
-                result = slack_web_client.conversations_history(
-                    channel=channel_id, inclusive=True, oldest=ts, limit=1
-                )
-                message = result["messages"][0]
-                if "files" in message:
-                    for file in message["files"]:
-                        if "image" in file["mimetype"]:
-                            if not file["public_url_shared"]:
-                                # Make the attachment public temporarily
-                                try:
-                                    slack_web_client.files_sharedPublicURL(
-                                        file=file["id"],
-                                        token=config.slack_user_token,
-                                    )
-                                except SlackApiError as error:
-                                    logger.error(
-                                        f"Error preparing pinned file for copy: {error}"
-                                    )
-                            # Copy the attachment into the database
-                            pub_secret = file["permalink_public"].split("-")[3]
-                            res = requests.get(
-                                file["url_private"],
-                                headers={
-                                    "Authorization": f"Bearer {config.slack_bot_token}"
-                                },
-                                params={"pub_secret": pub_secret},
-                            )
-                            write_content(
-                                incident_id=channel_info["channel"]["name"],
-                                title=file["name"],
-                                img=res.content,
-                                mimetype=file["mimetype"],
-                                ts=tools.fetch_timestamp(short=True),
-                                user=get_user_name(user_id=message["user"]),
-                            )
-                            # Revoke public access
-                            try:
-                                slack_web_client.files_revokePublicURL(
-                                    file=file["id"],
-                                    token=config.slack_user_token,
-                                )
-                            except SlackApiError as error:
-                                logger.error(
-                                    f"Error preparing pinned file for copy: {error}"
-                                )
-                        else:
-                            say(
-                                channel=channel_id,
-                                text=f":wave: Hey there! It looks like that's not an image. I can currently only attach images.",
-                            )
-                else:
-                    write_content(
-                        incident_id=channel_info["channel"]["name"],
-                        content=message["text"],
-                        ts=tools.fetch_timestamp(short=True),
-                        user=get_user_name(user_id=message["user"]),
-                    )
-            except Exception as error:
-                logger.error(
-                    f"Error when trying to retrieve a message: {error}"
-                )
-            finally:
-                try:
-                    slack_web_client.reactions_add(
-                        channel=channel_id,
-                        name="white_check_mark",
-                        timestamp=ts,
-                    )
-                except Exception as error:
-                    if "already_reacted" in str(error):
-                        reason = (
-                            "It looks like I've already pinned that content."
-                        )
-                    else:
-                        reason = f"Something went wrong: {error}"
-                    say(
-                        channel=channel_id,
-                        text=f":wave: Hey there! I was unable to pin that message. {reason}",
-                    )
+    try:
+        incident = db_read_incident(channel_id=channel_id)
+        logger.debug("reaction_added: incident '%s", incident)
+    except Exception as exc:
+        logger.debug("reaction_added: Failed to lookup incident with channel_id: '%s' - error: %s",
+                     channel_id, exc)
+        # Not a channel matching any incident tracked in the DB
+        return
+
+    # Retrieve the content of the message that was reacted to
+    try:
+        result = slack_web_client.conversations_history(
+            channel=channel_id, inclusive=True, oldest=ts, limit=1
+        )
+    except Exception as error:
+        logger.error("Failed to retrieve a message: error: %s", error)
+        return
+
+    logger.debug("reaction: channel_id: %s conversation_history result: %s", channel_id, result)
+    message = MessageContent(result["messages"][0])
+    logger.debug("reaction_added: message: %s", message)
+    message.store_to_db(incident.incident_id, lambda x: say(channel=channel_id, text=f":wave: {x}"))
+    if config.active.integrations.get("github"):
+        message.as_github_issue_comment(incident)
+    try:
+        slack_web_client.reactions_add(
+            channel=channel_id,
+            name="white_check_mark",
+            timestamp=ts,
+        )
+    except Exception as error:
+        if "already_reacted" in str(error):
+            reason = "It looks like I've already pinned that content."
+        else:
+            reason = f"Something went wrong: {error}"
+        say(
+            channel=channel_id,
+            text=f":wave: Hey there! I was unable to pin that message. {reason}",
+        )
 
 
 """
@@ -322,11 +377,11 @@ Helper Functions
 
 
 @app.event("message")
-def handle_message_events(body, logger):
-    logger.debug(body)
+def handle_message_events(body):
     """
     Handle monitoring digest channel
     """
+    logger.debug("handle_message_events: body: %s", body)
     if (
         # The presence of subtype indicates events like message updates, etc.
         # We don't want to act on these.
@@ -420,7 +475,7 @@ def handle_static_action(ack, body):
 
 
 @app.action("statuspage.components_status_select")
-def handle_static_action(ack, body, logger):
+def handle_static_action(ack, body):
     logger.debug(body)
     ack()
 
@@ -455,7 +510,7 @@ Jira
 
 
 @app.action("jira.description_input")
-def handle_static_action(ack, body, logger):
+def handle_static_action(ack, body):
     logger.debug(body)
     ack()
 

--- a/backend/bot/slack/modals.py
+++ b/backend/bot/slack/modals.py
@@ -8,7 +8,7 @@ from bot.audit.log import read as read_logs, write as write_log
 from bot.exc import ConfigurationError
 from bot.incident import incident
 from bot.jira.issue import JiraIssue
-from bot.github.issue import GithubIssue
+from bot.github import GithubIssue
 from bot.models.incident import (
     db_read_all_incidents,
     db_read_incident_channel_id,
@@ -73,9 +73,9 @@ def update_home_tab(client, event, logger):
             "text": {
                 "type": "mrkdwn",
                 "text": "*Hi there, <@"
-                + event["user"]
-                + "> :wave:*!\n\nI'm your friendly Incident Bot, and my "
-                + "sole purpose is to help us identify and run incidents.\n",
+                        + event["user"]
+                        + "> :wave:*!\n\nI'm your friendly Incident Bot, and my "
+                        + "sole purpose is to help us identify and run incidents.\n",
             },
         },
         {
@@ -91,9 +91,9 @@ def update_home_tab(client, event, logger):
             "text": {
                 "type": "mrkdwn",
                 "text": "To start a new incident, you can do the following:\n"
-                + "- Use the button here\n "
-                + "- Search for 'start a new incident' in the Slack search bar\n"
-                + "- type _/start_ in any Slack channel to find my command and run it.",
+                        + "- Use the button here\n "
+                        + "- Search for 'start a new incident' in the Slack search bar\n"
+                        + "- type _/start_ in any Slack channel to find my command and run it.",
             },
         },
         {
@@ -182,9 +182,9 @@ def open_modal(ack, body, client):
             "text": {
                 "type": "mrkdwn",
                 "text": "This will start a new incident channel and you will "
-                + "be invited to it. From there, please use our incident "
-                + "management process to run the incident or coordinate "
-                + "with others to do so.",
+                        + "be invited to it. From there, please use our incident "
+                        + "management process to run the incident or coordinate "
+                        + "with others to do so.",
             },
         },
         {
@@ -327,7 +327,7 @@ def open_modal(ack, body, client):
                         "text": {
                             "type": "mrkdwn",
                             "text": ":point_right: *The following teams will "
-                            + "be automatically paged when this incident is created:*",
+                                    + "be automatically paged when this incident is created:*",
                         },
                     },
                 ]
@@ -381,17 +381,17 @@ def handle_submission(ack, body, client):
             is_security_incident=parsed.get(
                 "open_incident_modal_set_security_type"
             )
-            in (
-                "True",
-                "true",
-                True,
-            ),
+                                 in (
+                                     "True",
+                                     "true",
+                                     True,
+                                 ),
             private_channel=parsed.get("open_incident_modal_set_private")
-            in (
-                "True",
-                "true",
-                True,
-            ),
+                            in (
+                                "True",
+                                "true",
+                                True,
+                            ),
         )
         resp = incident.create_incident(request_parameters)
         client.chat_postMessage(channel=user, text=resp)
@@ -421,9 +421,9 @@ def open_modal(ack, body, client):
                 "text": {
                     "type": "mrkdwn",
                     "text": "This will send a formatted, timestamped message "
-                    + "to the public incidents channel to provide an update "
-                    + "on the status of an incident. Use this to keep those "
-                    + "outside the incident process informed.",
+                            + "to the public incidents channel to provide an update "
+                            + "on the status of an incident. Use this to keep those "
+                            + "outside the incident process informed.",
                 },
             },
             {
@@ -719,8 +719,8 @@ def update_modal(ack, body, client):
                     "text": {
                         "type": "mrkdwn",
                         "text": "*You have selected the following options - please review them carefully.*\n\n"
-                        + "Once you click Submit, an incident will be created in PagerDuty for the team listed here"
-                        + " and they will be paged. They will also be invited to the incident's Slack channel.",
+                                + "Once you click Submit, an incident will be created in PagerDuty for the team listed here"
+                                + " and they will be paged. They will also be invited to the incident's Slack channel.",
                     },
                 },
                 {"type": "divider"},
@@ -794,7 +794,7 @@ def handle_submission(ack, body, say, view):
         say(
             channel=incident_channel_id,
             text=f"*NOTICE:* I have paged the team/escalation policy '{team}' "
-            + f"to respond to this incident via PagerDuty at the request of *{paging_user}*.",
+                 + f"to respond to this incident via PagerDuty at the request of *{paging_user}*.",
             blocks=[
                 {
                     "type": "header",
@@ -917,7 +917,7 @@ def update_modal(ack, body, client):
             "text": {
                 "type": "mrkdwn",
                 "text": "Add a new event to the incident's timeline. This will "
-                + "be automatically added to the RCA when the incident is resolved.\n",
+                        + "be automatically added to the RCA when the incident is resolved.\n",
             },
         },
         {"type": "divider"},
@@ -1118,8 +1118,8 @@ def open_modal(ack, body, client):
             "text": {
                 "type": "mrkdwn",
                 "text": "This Statuspage incident will start in "
-                + "*investigating* mode. You may change its status as the "
-                + "incident proceeds.",
+                        + "*investigating* mode. You may change its status as the "
+                        + "incident proceeds.",
             },
         },
         {"type": "divider"},
@@ -1128,9 +1128,9 @@ def open_modal(ack, body, client):
             "text": {
                 "type": "mrkdwn",
                 "text": "Please enter a brief description that will appear "
-                + "as the incident description in the Statuspage incident. "
-                + "Then select impacted components and confirm. Once "
-                + "confirmed, the incident will be opened.",
+                        + "as the incident description in the Statuspage incident. "
+                        + "Then select impacted components and confirm. Once "
+                        + "confirmed, the incident will be opened.",
             },
         },
         {"type": "divider"},
@@ -1274,32 +1274,12 @@ def open_modal(ack, body, client):
 
     # Return modal only if user has permissions
     sp_config = config.active.integrations.get("statuspage")
-    if sp_config.get("permissions") and sp_config.get("permissions").get(
-        "groups"
-    ):
-        for gr in sp_config.get("permissions").get("groups"):
-            if check_user_in_group(user_id=user, group_name=gr):
-                client.views_open(
-                    trigger_id=body["trigger_id"],
-                    view={
-                        "type": "modal",
-                        # View identifier
-                        "callback_id": "open_statuspage_incident_modal",
-                        "title": {
-                            "type": "plain_text",
-                            "text": "Statuspage Incident",
-                        },
-                        "submit": {"type": "plain_text", "text": "Start"},
-                        "blocks": blocks,
-                    },
-                )
-            else:
-                client.chat_postEphemeral(
-                    channel=incident_id,
-                    user=user,
-                    text="You don't have permissions to manage Statuspage incidents.",
-                )
-    else:
+    if (not sp_config.get("permissions")
+            or not sp_config.get("permissions").get("groups")
+            or any(g for g in sp_config["permissions"]["groups"]
+                   if check_user_in_group(user_id=user, group_name=g))):
+        # either not groups were configured of the user is in the group permitted to create
+        # StatusPage incidents
         client.views_open(
             trigger_id=body["trigger_id"],
             view={
@@ -1313,6 +1293,12 @@ def open_modal(ack, body, client):
                 "submit": {"type": "plain_text", "text": "Start"},
                 "blocks": blocks,
             },
+        )
+    else:
+        client.chat_postEphemeral(
+            channel=incident_id,
+            user=user,
+            text="You don't have permissions to manage Statuspage incidents.",
         )
 
 
@@ -1458,7 +1444,7 @@ def open_modal(ack, body, client):
     # Return modal only if user has permissions
     sp_config = config.active.integrations.get("statuspage")
     if sp_config.get("permissions") and sp_config.get("permissions").get(
-        "groups"
+            "groups"
     ):
         for gr in sp_config.get("permissions").get("groups"):
             if check_user_in_group(user_id=user, group_name=gr):
@@ -2049,8 +2035,8 @@ def handle_submission(ack, body, client, view):
         return None
 
     try:
-        issue = GithubIssue(
-            channel_id=channel_id,
+        issue = GithubIssue(incident=db_read_incident(channel_id=channel_id))
+        issue.new(
             description=parsed.get("github.description_input"),
             start_time=datetime.fromisoformat(parsed.get("github.start_time_input")),
             detection_time=datetime.fromisoformat(parsed.get("github.detection_time_input")),
@@ -2067,58 +2053,58 @@ def handle_submission(ack, body, client, view):
                      channel_id, exc)
         # Report failure
         send_msg(blocks=[
-                    {
-                        "type": "section",
-                        "text": {
-                            "type": "mrkdwn",
-                            "text": f"Failed to create GitHub issue.",
-                        },
-                    },
-                    {
-                        "type": "section",
-                        "text": {
-                            "type": "mrkdwn",
-                            "text": f"*Error:* {exc}",
-                        },
-                    },
-                ],
-                text=f"Failed to create Github issue",
+            {
+                "type": "section",
+                "text": {
+                    "type": "mrkdwn",
+                    "text": f"Failed to create GitHub issue.",
+                },
+            },
+            {
+                "type": "section",
+                "text": {
+                    "type": "mrkdwn",
+                    "text": f"*Error:* {exc}",
+                },
+            },
+        ],
+            text=f"Failed to create Github issue",
         )
         return
 
     # Report success
     resp = send_msg(blocks=[
-            {
-                "type": "section",
-                "text": {
-                    "type": "mrkdwn",
-                    "text": f"GitHub issue has been created for this incident in {issue.repository}.",
-                },
+        {
+            "type": "section",
+            "text": {
+                "type": "mrkdwn",
+                "text": f"GitHub issue has been created for this incident in {issue.repository}.",
             },
-            {
-                "type": "section",
-                "text": {
-                    "type": "mrkdwn",
-                    "text": f"*Title:* {issue.title}",
-                },
+        },
+        {
+            "type": "section",
+            "text": {
+                "type": "mrkdwn",
+                "text": f"*Title:* {issue.title}",
             },
-            {
-                "type": "actions",
-                "block_id": "github_view_issue",
-                "elements": [
-                    {
-                        "type": "button",
-                        "action_id": "github.view_issue",
-                        "style": "primary",
-                        "text": {
-                            "type": "plain_text",
-                            "text": "View Issue",
-                        },
-                        "url": issue.link,
+        },
+        {
+            "type": "actions",
+            "block_id": "github_view_issue",
+            "elements": [
+                {
+                    "type": "button",
+                    "action_id": "github.view_issue",
+                    "style": "primary",
+                    "text": {
+                        "type": "plain_text",
+                        "text": "View Issue",
                     },
-                ],
-            },
-        ],
+                    "url": issue.link,
+                },
+            ],
+        },
+    ],
         text=f"Github issue #{issue.number} with title {issue.title} has been created for this incident",
     )
     if resp:

--- a/backend/bot/statuspage/handler.py
+++ b/backend/bot/statuspage/handler.py
@@ -2,7 +2,6 @@ import config
 import json
 import requests
 
-from bot.audit import log
 from bot.models.incident import (
     db_read_incident,
     db_update_incident_sp_data_col,
@@ -271,26 +270,26 @@ class StatuspageIncidentUpdate:
 class StatuspageComponents:
     """Return and use Statuspage components"""
 
-    def __init__(self) -> List[Dict[str, str]]:
+    def __init__(self):
         """Retrieves a list of components from the Statuspage API
         for the supplied page ID
 
         Returns Dict[str, str] containing the formatted message
         to be sent to Slack
         """
-        components_raw = requests.get(
+        resp = requests.get(
             f"{api}/pages/{page_id}/components",
             headers=headers,
         )
-        self.resp = json.loads(components_raw.text)
+        self.components = resp.json()
 
     @property
     def list_of_names(self) -> List[str]:
-        return [c["name"] for c in self.resp]
+        return [c["name"] for c in self.components]
 
     @property
     def list_of_dict_name_ids(self) -> List[Dict[str, str]]:
-        return [{c["name"]: c["id"]} for c in self.resp]
+        return [{c["name"]: c["id"]} for c in self.components]
 
     def formatted_components_update(
         self, selected_components: List[str], status: str
@@ -307,18 +306,18 @@ class StatuspageComponents:
 class StatuspageObjects:
     """Return and use Statuspage objects"""
 
-    def __init__(self) -> List[Dict[str, str]]:
+    def __init__(self):
         """Retrieves a list of components from the Statuspage API
         for the supplied page ID
 
         Returns Dict[str, str] containing the formatted message
         to be sent to Slack
         """
-        incidents_raw = requests.get(
+        resp = requests.get(
             f"{api}/pages/{page_id}/incidents",
             headers=headers,
         )
-        self.open_incidents = json.loads(incidents_raw.text)
+        self.open_incidents = resp.json()
 
     @property
     def open_incidents(self) -> Dict[str, str]:

--- a/backend/config.py
+++ b/backend/config.py
@@ -406,9 +406,6 @@ slack_user_token = os.getenv("SLACK_USER_TOKEN")
 Statuspage Module
 """
 statuspage_api_key = os.getenv("STATUSPAGE_API_KEY", default="")
-statuspage_integration_enabled = os.getenv(
-    "STATUSPAGE_INTEGRATION_ENABLED", default="false"
-)
 statuspage_page_id = os.getenv("STATUSPAGE_PAGE_ID", default="")
 sp_logo_url = "https://i.imgur.com/v4xmF6u.png"
 
@@ -515,7 +512,6 @@ def env_check(required_envs: List[str]):
         for var in [
             "STATUSPAGE_API_KEY",
             "STATUSPAGE_PAGE_ID",
-            "STATUSPAGE_URL",
         ]:
             if os.getenv(var) == "":
                 logger.fatal(

--- a/manifest.yaml
+++ b/manifest.yaml
@@ -63,6 +63,8 @@ settings:
       - app_mention
       - message.channels
       - reaction_added
+      - pin_added
+      - pin_removed
   interactivity:
     is_enabled: true
   org_deploy_enabled: false


### PR DESCRIPTION
Pinned messages mean either:
- messages explicit pinned to the channel
- messages to which 📌 reaction was added

In both cases, text of message and all attached files are extracted and:
- text and files containing images are stored in the incident-bot DB
- if GitHub integration is enabled and an GitHub issues was already created, comment is added to the issue containing text of the message and links to all attached files

_Note_: GitHub API does not support uploading comment attachments, so issue comments only contain links to Slack

Also contains:
- refactoring of the `GithubIssue` class supporting comment creation
- refactoring of handling of non-interesting Slack events and actions
- fix in incident-bot API preventing crash when user is not found in the DB
- simplification of handling of user permissions for StatusPage incident creation
- initial fixes in StatusPage handling (needs to be completely rewritten)
- simplification of timestamp handling
- formatting changes
- removal of unused config attributes and environment variables